### PR TITLE
Fix for #13

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,19 @@ var extensions = {
   '.yml': 'require-yaml'
 };
 
+function registerCoffee(module, options) {
+  // make sure that both pre 1.7.x and newer versions 
+  // of coffee-script will work
+  if (options && options.packagePath) {
+    try {
+      require(path.join(options.packagePath, 'register'));
+    }
+    catch (e) {
+      ; // ignore, we are using an older version of coffee-script
+    }
+  }
+}
+
 var register = {
   'node-jsx': function (module, options) {
     module.install({ extension: '.jsx', harmony: true });
@@ -31,30 +44,8 @@ var register = {
   'toml-require': function (module, options) {
     module.install();
   },
-  'coffee-script': function (module, options) {
-    // make sure that both pre 1.7.x and newer versions 
-    // of coffee-script will work
-    if (options && options.packagePath) {
-      try {
-        require(path.join(options.packagePath, 'register'));
-      }
-      catch (e) {
-        ; // ignore, we are using an older version of coffee-script
-      }
-    }
-  },
-  'iced-coffee-script': function (module, options) {
-    // make sure that both pre 1.7.x and newer versions 
-    // of iced-coffee-script will work
-    if (options && options.packagePath) {
-      try {
-        require(path.join(options.packagePath, 'register'));
-      }
-      catch (e) {
-        ; // ignore, we are using an older version of iced-coffee-script
-      }
-    }
-  }
+  'coffee-script': registerCoffee,
+  'iced-coffee-script': registerCoffee
 };
 
 var jsVariantExtensions = [

--- a/index.js
+++ b/index.js
@@ -25,30 +25,34 @@ var extensions = {
 };
 
 var register = {
-  'node-jsx': function (module, packagePath) {
+  'node-jsx': function (module, options) {
     module.install({ extension: '.jsx', harmony: true });
   },
-  'toml-require': function (module, packagePath) {
+  'toml-require': function (module, options) {
     module.install();
   },
-  'coffee-script': function (module, packagePath) {
+  'coffee-script': function (module, options) {
     // make sure that both pre 1.7.x and newer versions 
     // of coffee-script will work
-    try {
-      require(path.join(packagePath, 'register'));
-    }
-    catch (e) {
-      ; // ignore, we are using an older version of coffee-script
+    if (options && options.packagePath) {
+      try {
+        require(path.join(options.packagePath, 'register'));
+      }
+      catch (e) {
+        ; // ignore, we are using an older version of coffee-script
+      }
     }
   },
-  'iced-coffee-script': function (module, packagePath) {
+  'iced-coffee-script': function (module, options) {
     // make sure that both pre 1.7.x and newer versions 
     // of iced-coffee-script will work
-    try {
-      require(path.join(packagePath, 'register'));
-    }
-    catch (e) {
-      ; // ignore, we are using an older version of iced-coffee-script
+    if (options && options.packagePath) {
+      try {
+        require(path.join(options.packagePath, 'register'));
+      }
+      catch (e) {
+        ; // ignore, we are using an older version of iced-coffee-script
+      }
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,19 +1,22 @@
+const path = require('path');
+
 var extensions = {
   '.cjsx': 'node-cjsx/register',
   '.co': 'coco',
-  '.coffee': 'coffee-script/register',
-  '.coffee.md': 'coffee-script/register',
+  '.coffee': 'coffee-script',
+  '.coffee.md': 'coffee-script',
   '.csv': 'require-csv',
-  '.iced': 'iced-coffee-script/register',
-  '.iced.md': 'iced-coffee-script/register',
+  '.iced': 'iced-coffee-script',
+  '.iced.md': 'iced-coffee-script',
   '.ini': 'require-ini',
   '.js': null,
   '.json': null,
   '.json5': 'json5/lib/require',
   '.jsx': 'node-jsx',
-  '.litcoffee': 'coffee-script/register',
-  '.liticed': 'iced-coffee-script/register',
+  '.litcoffee': 'coffee-script',
+  '.liticed': 'iced-coffee-script',
   '.ls': 'LiveScript',
+  '.node' : null,
   '.toml': 'toml-require',
   '.ts': 'typescript-require',
   '.xml': 'require-xml',
@@ -22,11 +25,31 @@ var extensions = {
 };
 
 var register = {
-  'node-jsx': function (module) {
+  'node-jsx': function (module, packagePath) {
     module.install({ extension: '.jsx', harmony: true });
   },
-  'toml-require': function (module) {
+  'toml-require': function (module, packagePath) {
     module.install();
+  },
+  'coffee-script': function (module, packagePath) {
+    // make sure that both pre 1.7.x and newer versions 
+    // of coffee-script will work
+    try {
+      require(path.join(packagePath, 'register'));
+    }
+    catch (e) {
+      ; // ignore, we are using an older version of coffee-script
+    }
+  },
+  'iced-coffee-script': function (module, packagePath) {
+    // make sure that both pre 1.7.x and newer versions 
+    // of iced-coffee-script will work
+    try {
+      require(path.join(packagePath, 'register'));
+    }
+    catch (e) {
+      ; // ignore, we are using an older version of iced-coffee-script
+    }
   }
 };
 
@@ -42,6 +65,7 @@ var jsVariantExtensions = [
   '.litcoffee',
   '.liticed',
   '.ls',
+  '.node',
   '.ts'
 ];
 


### PR DESCRIPTION
- fixes #13: add support for older (iced-)coffee-script versions

Functions registered under register now take a second parameter: packagePath which is the resolved path of the package providing the module.
