### PR TITLE
allow config objects as alternative to string module names

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var extensions = {
   '.json': null,
   '.json5': 'json5/lib/require',
   '.jsx': 'node-jsx',
-  '.litcoffee': 'coffee-script/register', // TODO: litcoffee wasn't available in old coffee-script, correct?
+  '.litcoffee': 'coffee-script/register',
   '.liticed': 'iced-coffee-script/register',
   '.ls': 'LiveScript',
   '.toml': 'toml-require',
@@ -34,11 +34,12 @@ var legacyModules = {
   '.coffee': 'coffee-script',
   '.coffee.md': 'coffee-script',
   '.iced': 'iced-coffee-script',
-  '.iced.md': 'iced-coffee-script'
+  // .iced.md and .liticed weren't available before the register module
+  '.litcoffee': 'coffee-script'
 };
 
 var configurations = {
-  '.jsx': {
+  'node-jsx': {
     extension: '.jsx',
     harmony: true
   }

--- a/index.js
+++ b/index.js
@@ -1,17 +1,35 @@
 var extensions = {
   '.cjsx': 'node-cjsx/register',
   '.co': 'coco',
-  '.coffee': 'coffee-script/register',
-  '.coffee.md': 'coffee-script/register',
+  '.coffee': {
+    module: 'coffee-script/register',
+    legacyModules: ['coffee-script']
+  },
+  '.coffee.md': {
+    module: 'coffee-script/register',
+    legacyModules: ['coffee-script']
+  },
   '.csv': 'require-csv',
-  '.iced': 'iced-coffee-script/register',
-  '.iced.md': 'iced-coffee-script/register',
+  '.iced': {
+    module: 'iced-coffee-script/register',
+    legacyModules: ['iced-coffee-script']
+  },
+  '.iced.md': {
+    module: 'iced-coffee-script/register',
+    legacyModules: ['iced-coffee-script']
+  },
   '.ini': 'require-ini',
   '.js': null,
   '.json': null,
   '.json5': 'json5/lib/require',
-  '.jsx': 'node-jsx',
-  '.litcoffee': 'coffee-script/register',
+  '.jsx': {
+    module: 'node-jsx',
+    options: {
+      extension: '.jsx',
+      harmony: true
+    }
+  },
+  '.litcoffee': 'coffee-script/register', // TODO: litcoffee wasn't available in old coffee-script, correct?
   '.liticed': 'iced-coffee-script/register',
   '.ls': 'LiveScript',
   '.toml': 'toml-require',
@@ -22,8 +40,8 @@ var extensions = {
 };
 
 var register = {
-  'node-jsx': function (module) {
-    module.install({ extension: '.jsx', harmony: true });
+  'node-jsx': function (module, options) {
+    module.install(options);
   },
   'toml-require': function (module) {
     module.install();

--- a/index.js
+++ b/index.js
@@ -1,34 +1,16 @@
 var extensions = {
   '.cjsx': 'node-cjsx/register',
   '.co': 'coco',
-  '.coffee': {
-    module: 'coffee-script/register',
-    legacyModules: ['coffee-script']
-  },
-  '.coffee.md': {
-    module: 'coffee-script/register',
-    legacyModules: ['coffee-script']
-  },
+  '.coffee': 'coffee-script/register',
+  '.coffee.md': 'coffee-script/register',
   '.csv': 'require-csv',
-  '.iced': {
-    module: 'iced-coffee-script/register',
-    legacyModules: ['iced-coffee-script']
-  },
-  '.iced.md': {
-    module: 'iced-coffee-script/register',
-    legacyModules: ['iced-coffee-script']
-  },
+  '.iced': 'iced-coffee-script/register',
+  '.iced.md': 'iced-coffee-script/register',
   '.ini': 'require-ini',
   '.js': null,
   '.json': null,
   '.json5': 'json5/lib/require',
-  '.jsx': {
-    module: 'node-jsx',
-    options: {
-      extension: '.jsx',
-      harmony: true
-    }
-  },
+  '.jsx': 'node-jsx',
   '.litcoffee': 'coffee-script/register', // TODO: litcoffee wasn't available in old coffee-script, correct?
   '.liticed': 'iced-coffee-script/register',
   '.ls': 'LiveScript',
@@ -45,6 +27,20 @@ var register = {
   },
   'toml-require': function (module) {
     module.install();
+  }
+};
+
+var legacyModules = {
+  '.coffee': 'coffee-script',
+  '.coffee.md': 'coffee-script',
+  '.iced': 'iced-coffee-script',
+  '.iced.md': 'iced-coffee-script'
+};
+
+var configurations = {
+  '.jsx': {
+    extension: '.jsx',
+    harmony: true
   }
 };
 
@@ -65,6 +61,8 @@ var jsVariantExtensions = [
 
 module.exports = {
   extensions: extensions,
+  legacy: legacyModules,
+  configurations: configurations,
   register: register,
   jsVariants: jsVariantExtensions.reduce(function (result, ext) {
     result[ext] = extensions[ext];

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ var extensions = {
 };
 
 var register = {
-  'node-jsx': function (module, options) {
-    module.install(options);
+  'node-jsx': function (module, config) {
+    module.install(config);
   },
   'toml-require': function (module) {
     module.install();


### PR DESCRIPTION
I still have to update docs and node-rechoir/liftoff but I wanted @tkellen and @silkentrance to see if this solves all outstanding problems/issues.  Notice that I moved the .jsx options out into the extension declaration; this will allow people to adjust config options before calling rechoir.load/registerFor instead of having to redefine the function on register.

Thoughts?