### PR TITLE
`.node` is a native Node loader.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var extensions = {
   '.litcoffee': 'coffee-script/register',
   '.liticed': 'iced-coffee-script/register',
   '.ls': 'LiveScript',
+  '.node': null,
   '.toml': 'toml-require',
   '.ts': 'typescript-register',
   '.wisp': 'wisp/engine/node',


### PR DESCRIPTION
It's been there the whole time, as a way to load and interface with native C++ modules.